### PR TITLE
feat: 监听iOS 通过 universal link 打开 APP

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,11 +371,32 @@ Wechat.openCustomerServiceChat(
 
 ```js
 // 监听开放标签拉起APP的事件
-Wechat.subscribe((extinfo) => {
+Wechat.listenLaunchFromWX((extinfo) => {
   // 已拉起APP，参数是extinfo
-  console.log("extinfo:", extinfo);
+  console.log("extinfo: ", extinfo);
 });
 
-// 取消订阅时间
-Wechat.unsubscribe();
+// 取消监听事件
+Wechat.unListenLaunchFromWX();
+```
+
+### iOS 通过 universal link 打开 APP
+
+**该方法仅 iOS 有效。**
+
+由于微信登录跳转回 APP 使用的是 universal link，所以该插件必须监听 universal link 打开 APP 的事件才能处理登录逻辑。
+
+但是这样会使[cordova-wtto00-universal-link](https://github.com/wtto00/cordova-wtto00-universal-link)插件监听的打开 APP 失效。
+
+所以添加此方法，如果两者同时存在的话，iOS 在微信的监听方法中处理；安卓在原插件处理即可，不受影响。
+
+```js
+// 监听universal link拉起APP的事件
+Wechat.listenLaunchFromUL((url) => {
+  // 已拉起APP，参数是url
+  console.log("universal link: ", url);
+});
+
+// 取消监听事件
+Wechat.unListenLaunchFromUL();
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-wtto00-wechat",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "微信 cordova 插件",
   "types": "./types/index.d.ts",
   "files": [

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:rim="http://www.blackberry.com/ns/widgets"
-    xmlns:android="http://schemas.android.com/apk/res/android" id="cordova-wtto00-wechat" version="1.2.0">
+    xmlns:android="http://schemas.android.com/apk/res/android" id="cordova-wtto00-wechat" version="1.3.0">
 
     <name>Wechat</name>
     <description>微信 cordova 插件</description>

--- a/src/android/Wechat.java
+++ b/src/android/Wechat.java
@@ -7,7 +7,6 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.net.Uri;
 import android.os.Environment;
-import android.text.TextUtils;
 import android.util.Base64;
 import android.util.Log;
 import android.webkit.URLUtil;
@@ -15,6 +14,7 @@ import android.webkit.URLUtil;
 import androidx.core.content.FileProvider;
 
 import com.tencent.mm.opensdk.constants.Build;
+import com.tencent.mm.opensdk.modelbiz.ChooseCardFromWXCardPackage;
 import com.tencent.mm.opensdk.modelbiz.WXLaunchMiniProgram;
 import com.tencent.mm.opensdk.modelbiz.WXOpenCustomerServiceChat;
 import com.tencent.mm.opensdk.modelmsg.SendAuth;
@@ -24,35 +24,31 @@ import com.tencent.mm.opensdk.modelmsg.WXEmojiObject;
 import com.tencent.mm.opensdk.modelmsg.WXFileObject;
 import com.tencent.mm.opensdk.modelmsg.WXImageObject;
 import com.tencent.mm.opensdk.modelmsg.WXMediaMessage;
+import com.tencent.mm.opensdk.modelmsg.WXMiniProgramObject;
 import com.tencent.mm.opensdk.modelmsg.WXMusicObject;
 import com.tencent.mm.opensdk.modelmsg.WXTextObject;
 import com.tencent.mm.opensdk.modelmsg.WXVideoObject;
 import com.tencent.mm.opensdk.modelmsg.WXWebpageObject;
-import com.tencent.mm.opensdk.modelmsg.WXMiniProgramObject;
 import com.tencent.mm.opensdk.modelpay.PayReq;
 import com.tencent.mm.opensdk.openapi.IWXAPI;
 import com.tencent.mm.opensdk.openapi.WXAPIFactory;
 
-import com.tencent.mm.opensdk.modelbiz.ChooseCardFromWXCardPackage;
-
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaArgs;
 import org.apache.cordova.CordovaPlugin;
+import org.apache.cordova.CordovaPreferences;
 import org.apache.cordova.PluginResult;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.ByteArrayOutputStream;
-
-import org.apache.cordova.CordovaPreferences;
-
 import java.util.Date;
 
 public class Wechat extends CordovaPlugin {
@@ -185,10 +181,10 @@ public class Wechat extends CordovaPlugin {
             return openMiniProgram(args, callbackContext);
         } else if (action.equals("openCustomerServiceChat")) {
             return openCustomerServiceChat(args, callbackContext);
-        } else if (action.equals(("jsSubscribeForEvent"))) {
-            return subscribeForEvent(callbackContext);
-        } else if (action.equals("jsUnsubscribeFromEvent")) {
-            return unsubscribeFromEvent();
+        } else if (action.equals(("listenLaunchFromWX"))) {
+            return listenLaunchFromWX(callbackContext);
+        } else if (action.equals("unListenLaunchFromWX")) {
+            return unListenLaunchFromWX();
         }
 
         return false;
@@ -884,17 +880,17 @@ public class Wechat extends CordovaPlugin {
         return true;
     }
 
-    private static CallbackContext subscribeEventCallback;
+    private static CallbackContext listenLaunchFromWXCallback;
 
-    protected boolean subscribeForEvent(CallbackContext callbackContext) {
-        subscribeEventCallback = callbackContext;
-        Log.i(TAG, "init subscribeForEvent");
+    protected boolean listenLaunchFromWX(CallbackContext callbackContext) {
+        listenLaunchFromWXCallback = callbackContext;
+        Log.i(TAG, "init listenLaunchFromWX");
         tryToConsumeEvent(null);
         return true;
     }
 
-    protected boolean unsubscribeFromEvent() {
-        subscribeEventCallback = null;
+    protected boolean unListenLaunchFromWX() {
+        listenLaunchFromWXCallback = null;
         return true;
     }
 
@@ -902,12 +898,12 @@ public class Wechat extends CordovaPlugin {
      * Try to send event to the subscribers.
      */
     public static void tryToConsumeEvent(String message) {
-        if (message == null || subscribeEventCallback == null) {
+        if (message == null || listenLaunchFromWXCallback == null) {
             return;
         }
 
         Log.i(TAG, "wechat send message to js: " + message);
-        sendMessageToJs(message, subscribeEventCallback);
+        sendMessageToJs(message, listenLaunchFromWXCallback);
     }
 
     /**

--- a/src/ios/CDVWechat.h
+++ b/src/ios/CDVWechat.h
@@ -33,6 +33,8 @@ enum  CDVWechatSharingType {
 - (void)openCustomerServiceChat: (CDVInvokedUrlCommand *)command;
 - (BOOL)handleUserActivity:(NSUserActivity *)userActivity;
 - (BOOL)handleWechatOpenURL:(NSURL *)url;
-- (void)jsSubscribeForEvent:(CDVInvokedUrlCommand *)command;
-- (void)jsUnsubscribeFromEvent:(CDVInvokedUrlCommand *)command;
+- (void)listenLaunchFromWX:(CDVInvokedUrlCommand *)command;
+- (void)unListenLaunchFromWX:(CDVInvokedUrlCommand *)command;
+- (void)listenLaunchFromUL:(CDVInvokedUrlCommand *)command;
+- (void)unListenLaunchFromUL:(CDVInvokedUrlCommand *)command;
 @end

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -391,15 +391,26 @@ declare namespace Wechat {
   ): void;
 
   /**
-   * 订阅微信开放标签<wx-open-launch-app>打开APP后的事件
-   * 重复多次订阅会覆盖，以最后订阅的事件为准
+   * 监听微信开放标签<wx-open-launch-app>打开APP后的事件
+   * 重复多次监听会覆盖，以最后监听的事件为准
    */
-  function subscribe(callback: (msg?: string) => void): void;
+  function listenLaunchFromWX(callback: (msg?: string) => void): void;
 
   /**
-   * 取消订阅微信开放标签<wx-open-launch-app>打开APP后的事件
+   * 取消监听微信开放标签<wx-open-launch-app>打开APP后的事件
    */
-  function unsubscribe(): void;
+  function unListenLaunchFromWX(): void;
+
+  /**
+   * 监听通过 universal link 打开 APP。
+   * **仅iOS有效**
+   */
+  function listenLaunchFromUL(callback: (url: string) => void): void;
+
+  /**
+   * 取消监听universal link 打开 APP的事件
+   */
+  function unListenLaunchFromUL(): void;
 }
 
 interface Window {

--- a/www/wechat.js
+++ b/www/wechat.js
@@ -79,7 +79,7 @@ module.exports = {
   },
 
   listenLaunchFromUL: function (callback) {
-    if (platform !== 'ios') return
+    if (platform.id !== 'ios') return
     if (!callback) {
       console.warn("Cordova Wechat: can't listen to event without a callback");
       return;
@@ -93,7 +93,7 @@ module.exports = {
   },
 
   unListenLaunchFromUL: function () {
-    if (platform !== 'ios') return
+    if (platform.id !== 'ios') return
     exec(null, null, "Wechat", "unListenLaunchFromUL", []);
   },
 };

--- a/www/wechat.js
+++ b/www/wechat.js
@@ -1,4 +1,5 @@
 var exec = require("cordova/exec");
+var platform = require("cordova/platform")
 
 module.exports = {
   Scene: {
@@ -60,9 +61,9 @@ module.exports = {
     exec(onSuccess, onError, "Wechat", "openCustomerServiceChat", [params]);
   },
 
-  subscribe: function (callback) {
+  listenLaunchFromWX: function (callback) {
     if (!callback) {
-      console.warn("Cordova Wechat: can't subscribe to event without a callback");
+      console.warn("Cordova Wechat: can't listen to event without a callback");
       return;
     }
 
@@ -70,10 +71,29 @@ module.exports = {
       callback(msg);
     };
 
-    exec(innerCallback, null, "Wechat", "jsSubscribeForEvent", []);
+    exec(innerCallback, null, "Wechat", "listenLaunchFromWX", []);
   },
 
-  unsubscribe: function () {
-    exec(null, null, "Wechat", "jsUnsubscribeFromEvent", []);
+  unListenLaunchFromWX: function () {
+    exec(null, null, "Wechat", "unListenLaunchFromWX", []);
+  },
+
+  listenLaunchFromUL: function (callback) {
+    if (platform !== 'ios') return
+    if (!callback) {
+      console.warn("Cordova Wechat: can't listen to event without a callback");
+      return;
+    }
+
+    var innerCallback = function (msg) {
+      callback(msg);
+    };
+
+    exec(innerCallback, null, "Wechat", "listenLaunchFromUL", []);
+  },
+
+  unListenLaunchFromUL: function () {
+    if (platform !== 'ios') return
+    exec(null, null, "Wechat", "unListenLaunchFromUL", []);
   },
 };


### PR DESCRIPTION
### iOS 通过 universal link 打开 APP

**该方法仅 iOS 有效。**

由于微信登录跳转回 APP 使用的是 universal link，所以该插件必须监听 universal link 打开 APP 的事件才能处理登录逻辑。

但是这样会使[cordova-wtto00-universal-link](https://github.com/wtto00/cordova-wtto00-universal-link)插件监听的打开 APP 失效。

所以添加此方法，如果两者同时存在的话，iOS 监听universal link 打开 APP在微信的这个方法中处理；安卓在原插件处理即可，不受影响。

```js
// 监听universal link拉起APP的事件
Wechat.listenLaunchFromUL((url) => {
  // 已拉起APP，参数是url
  console.log("universal link: ", url);
});

// 取消监听事件
Wechat.unListenLaunchFromUL();
```
